### PR TITLE
fix: 修复城市信息中可能的空字段

### DIFF
--- a/nonebot_plugin_kfcrazy/__init__.py
+++ b/nonebot_plugin_kfcrazy/__init__.py
@@ -65,11 +65,11 @@ class KFC:
             city_list = resp_json['data']['allCities']
             for city in city_list:
                 city_name = city['cityNameZh']
-                district_name = city['districtName']
+                district_name = city.get('districtName', '')
                 if ' ' not in param_city:
                     if param_city in city_name and district_name == '':
                         CityCode = city['cityCode']
-                        DistrictCode = city['districtCode']
+                        DistrictCode = city.get('districtCode', '')
                         Lat = city['latitude']
                         Lng = city['longitude']
                         break
@@ -117,7 +117,7 @@ class KFC:
         i, store_id_list = 0, []
         for store_name in data_list:
             store_list += str(i) + '.' + \
-                          store_name['storename'] + '\n'
+                store_name['storename'] + '\n'
             store_code = store_name['storecode']
             store_id_list.append(store_code)
             i += 1


### PR DESCRIPTION
在接口`https://selectstore.hwwt8.com/store-portal/wx/api/city/cities`返回信息中，allCities数组中的对象里，可能不存在`districtName`和`districtCode`字段导致出错。
![uTools_1668074869574](https://user-images.githubusercontent.com/74779439/201062600-aea7695e-7c6f-4634-865e-90ceed5c543a.png)
